### PR TITLE
buildFailedPermalink

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,7 @@ Edit the main config file, usually `.BuildServer/config/main-config.xml` and add
     <slackDefaultChannel>#general</slackDefaultChannel>
     <slackPostUrl>https://hooks.slack.com/services/YYYYYY/XXXXXXX/ZZZZZZZZZZZZ</slackPostUrl>
     <slackLogoUrl>http://build.tapadoo.com/img/icons/TeamCity32.png</slackLogoUrl>
+    <buildFailedPermalink>http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;buildId=lastFinished</buildFailedPermalink>
   </slackNotifier>
   ...
   ...

--- a/src/main/java/com/tapadoo/slacknotifier/SlackConfigProcessor.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackConfigProcessor.java
@@ -64,7 +64,7 @@ public class SlackConfigProcessor implements MainConfigProcessor {
     }
 
     public String getBuildFailedPermalink(){
-        return this.buildFailedPermalink;
+        return buildFailedPermalink;
     }
 
     public void setBuildFailedPermalink(String permalink){

--- a/src/main/java/com/tapadoo/slacknotifier/SlackConfigProcessor.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackConfigProcessor.java
@@ -13,6 +13,7 @@ public class SlackConfigProcessor implements MainConfigProcessor {
     public static final String PREF_KEY_SLACK_DEF_CHANNEL = "slackDefaultChannel";
     public static final String PREF_KEY_SLACK_POSTURL = "slackPostUrl";
     public static final String PREF_KEY_SLACK_LOGOURL = "slackLogoUrl";
+    public static final String PREF_KEY_BUILD_FAILED_PERMALINK = "buildFailedPermalink";
 
     private static final java.lang.String PREF_CHILD_ELEMENT = "slackNotifier";
 
@@ -23,6 +24,7 @@ public class SlackConfigProcessor implements MainConfigProcessor {
     private String defaultChannel = "#general";
     private String postUrl;
     private String logoUrl;
+    private String buildFailedPermalink;
 
     private boolean postSuccessful = true ;
     private boolean postStarted = false ;
@@ -61,6 +63,14 @@ public class SlackConfigProcessor implements MainConfigProcessor {
         this.defaultChannel = defaultChannel;
     }
 
+    public String getBuildFailedPermalink(){
+        return this.buildFailedPermalink;
+    }
+
+    public void setBuildFailedPermalink(String permalink){
+        this.buildFailedPermalink = permalink;
+    }
+
     public String getPostUrl() {
         return postUrl;
     }
@@ -89,6 +99,7 @@ public class SlackConfigProcessor implements MainConfigProcessor {
         defaultChannel = mainConfigElement.getChildText(PREF_KEY_SLACK_DEF_CHANNEL);
         postUrl = mainConfigElement.getChildText(PREF_KEY_SLACK_POSTURL);
         logoUrl = mainConfigElement.getChildText(PREF_KEY_SLACK_LOGOURL);
+        buildFailedPermalink = mainConfigElement.getChildText(PREF_KEY_BUILD_FAILED_PERMALINK);
 
         Attribute postSuccessfulAttr = mainConfigElement.getAttribute(ATTR_NAME_POST_SUCCESSFUL);
         Attribute postStartedAttr = mainConfigElement.getAttribute(ATTR_NAME_POST_STARTED);
@@ -135,12 +146,14 @@ public class SlackConfigProcessor implements MainConfigProcessor {
         Element defChannelElement = new Element(PREF_KEY_SLACK_DEF_CHANNEL);
         Element postUrlElement = new Element(PREF_KEY_SLACK_POSTURL);
         Element logoUrlElement = new Element(PREF_KEY_SLACK_LOGOURL);
+        Element buildFailedPermalinkElement = new Element(PREF_KEY_BUILD_FAILED_PERMALINK);
 
         defChannelElement.setText(defaultChannel);
 
         mainConfigElement.addContent(defChannelElement);
         mainConfigElement.addContent(postUrlElement);
         mainConfigElement.addContent(logoUrlElement);
+        mainConfigElement.addContent(buildFailedPermalinkElement);
 
         element.addContent(mainConfigElement);
 

--- a/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
@@ -111,8 +111,13 @@ public class SlackServerAdapter extends BuildServerAdapter {
                 .toFormatter();
 
         Duration buildDuration = new Duration(1000*build.getDuration());
+        
+        String buildFailedPermalink = this.slackConfig.getBuildFailedPermalink();
 
-        message = String.format("Project '%s' build failed! ( %s )" , build.getFullName() , durationFormatter.print(buildDuration.toPeriod()));
+        if (buildFailedPermalink != "")
+            message = String.format("Project '%s' build failed! ( %s )\n%s" , build.getFullName() , durationFormatter.print(buildDuration.toPeriod()), buildFailedPermalink);
+        else
+            message = String.format("Project '%s' build failed! ( %s )" , build.getFullName() , durationFormatter.print(buildDuration.toPeriod()));
 
         postToSlack(build, message, false);
     }

--- a/src/main/java/com/tapadoo/slacknotifier/webui/SlackAdminPage.java
+++ b/src/main/java/com/tapadoo/slacknotifier/webui/SlackAdminPage.java
@@ -44,5 +44,6 @@ public class SlackAdminPage extends AdminPage {
         model.put("defaultChannel" , configProcesser.getDefaultChannel());
         model.put("logoUrl" , configProcesser.getLogoUrl());
         model.put("postUrl" , configProcesser.getPostUrl());
+        model.put("buildFailedPermalink", configProcessor.getBuildFailedPermalink());
     }
 }

--- a/src/main/java/com/tapadoo/slacknotifier/webui/SlackAdminPage.java
+++ b/src/main/java/com/tapadoo/slacknotifier/webui/SlackAdminPage.java
@@ -15,7 +15,7 @@ import java.util.Map;
  */
 public class SlackAdminPage extends AdminPage {
 
-    private final SlackConfigProcessor configProcesser;
+    private final SlackConfigProcessor configProcessor;
 
     public SlackAdminPage(PagePlaces pagePlaces, PluginDescriptor descriptor , SlackConfigProcessor configProcessor) {
         super(pagePlaces);
@@ -25,7 +25,7 @@ public class SlackAdminPage extends AdminPage {
         setPosition(PositionConstraint.after("clouds", "email", "jabber"));
         register();
 
-        this.configProcesser = configProcessor ;
+        this.configProcessor = configProcessor ;
     }
 
     @Override
@@ -41,9 +41,9 @@ public class SlackAdminPage extends AdminPage {
     public void fillModel(Map<String, Object> model, HttpServletRequest request) {
         super.fillModel(model, request);
 
-        model.put("defaultChannel" , configProcesser.getDefaultChannel());
-        model.put("logoUrl" , configProcesser.getLogoUrl());
-        model.put("postUrl" , configProcesser.getPostUrl());
+        model.put("defaultChannel" , configProcessor.getDefaultChannel());
+        model.put("logoUrl" , configProcessor.getLogoUrl());
+        model.put("postUrl" , configProcessor.getPostUrl());
         model.put("buildFailedPermalink", configProcessor.getBuildFailedPermalink());
     }
 }

--- a/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
+++ b/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
@@ -20,7 +20,7 @@
             &lt;slackDefaultChannel&gt;#testing&lt;/slackDefaultChannel&gt;
             &lt;slackPostUrl&gt;https://hooks.slack.com/services/XXXXXXX/XXXXX/XXXXXXXX&lt;/slackPostUrl&gt;
             &lt;slackLogoUrl&gt;http://build.tapadoo.com/img/icons/TeamCity32.png&lt;/slackLogoUrl&gt;
-	        &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
+	        &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
         &lt;/slackNotifier&gt;
         ...
         ...

--- a/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
+++ b/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
@@ -20,7 +20,7 @@
             &lt;slackDefaultChannel&gt;#testing&lt;/slackDefaultChannel&gt;
             &lt;slackPostUrl&gt;https://hooks.slack.com/services/XXXXXXX/XXXXX/XXXXXXXX&lt;/slackPostUrl&gt;
             &lt;slackLogoUrl&gt;http://build.tapadoo.com/img/icons/TeamCity32.png&lt;/slackLogoUrl&gt;
-	        &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
+            &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
         &lt;/slackNotifier&gt;
         ...
         ...

--- a/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
+++ b/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
@@ -20,7 +20,7 @@
             &lt;slackDefaultChannel&gt;#testing&lt;/slackDefaultChannel&gt;
             &lt;slackPostUrl&gt;https://hooks.slack.com/services/XXXXXXX/XXXXX/XXXXXXXX&lt;/slackPostUrl&gt;
             &lt;slackLogoUrl&gt;http://build.tapadoo.com/img/icons/TeamCity32.png&lt;/slackLogoUrl&gt;
-	    &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
+	        &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
         &lt;/slackNotifier&gt;
         ...
         ...

--- a/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
+++ b/src/main/resources/buildServerResources/admin/slackAdminPage.jsp
@@ -7,6 +7,7 @@
 <p>
     <b>Post URL :</b> ${postUrl}</br>
     <b>Default Logo URL :</b> ${logoUrl}</br>
+    <b>Build Failed Permalink :</b> ${buildFailedPermalink}</br>
 </p>
 
 <h2>Configuration</h2>
@@ -19,6 +20,7 @@
             &lt;slackDefaultChannel&gt;#testing&lt;/slackDefaultChannel&gt;
             &lt;slackPostUrl&gt;https://hooks.slack.com/services/XXXXXXX/XXXXX/XXXXXXXX&lt;/slackPostUrl&gt;
             &lt;slackLogoUrl&gt;http://build.tapadoo.com/img/icons/TeamCity32.png&lt;/slackLogoUrl&gt;
+	    &lt;buildFailedPermalink&gt;http://build.tapadoo.com/viewLog.html?buildTypeId=XXXXXXX&amp;buildId=lastFinished&lt;/buildFailedPermalink&gt;
         &lt;/slackNotifier&gt;
         ...
         ...


### PR DESCRIPTION
This pull request adds a new attribute (buildFailedPermalink) which allows the plugin to post a permalink to the latest build log only when builds fail. This allows users to quickly jump directly from Slack straight to the failed build and assess the issue.


![pluginexample](https://cloud.githubusercontent.com/assets/6208902/12869115/ba6ed514-cce3-11e5-9bab-258c6ed58269.PNG)
