### PR TITLE
Moved commit message to Attachment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 
 
 sourceCompatibility = 1.8
-version = '4.0.2'
+version = '4.1.0'
 
 configurations {
     deploy

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 
 
 sourceCompatibility = 1.8
-version = '4.1.0'
+version = '4.1.1'
 
 configurations {
     deploy

--- a/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
@@ -183,24 +183,6 @@ public class SlackServerAdapter extends BuildServerAdapter {
             UserSet<SUser> committers = build.getCommitters(SelectPrevBuildPolicy.SINCE_LAST_BUILD);
             StringBuilder committersString = new StringBuilder();
 
-            List<SVcsModification>  changes =  build.getChanges(SelectPrevBuildPolicy.SINCE_LAST_SUCCESSFULLY_FINISHED_BUILD, true);
-
-            StringBuilder commitMessage = new StringBuilder();
-
-            /*
-             * If this field starts to feel too long in slack, we should only use the first item in the array, which would be the latest change
-             *
-             */
-            for ( int i = 0 ; i < changes.size() ; i++ ){
-                SVcsModification modification = changes.get(i);
-                String desc = modification.getDescription();
-                commitMessage.append(desc);
-
-                if( i < changes.size() - 1 ) {
-                    commitMessage.append("\n------\n");
-                }
-            }
-
             for( SUser committer : committers.getUsers() )
             {
                 if( committer != null)
@@ -314,21 +296,14 @@ public class SlackServerAdapter extends BuildServerAdapter {
                 fallbackMessage.append(issueIds.toString());
             }
 
-            /* TODO: Consider adding a setting to SlackProjectSettings perhaps to enable / disable commit messages at a project level? */
-            if( commitMessage.length() > 0 ) {
-                JsonObject field = new JsonObject() ;
-
-                field.addProperty("title", "Commit Messages");
-                field.addProperty("value",commitMessage.toString());
-                field.addProperty("short", false);
-
-                fields.add(field);
-            }
-
             attachment.addProperty("color", (goodColor ? "good" : "danger"));
-
-
             attachment.add("fields",fields);
+
+            JsonObject commitAttachment = createCommitAttachment(build);
+
+            if(commitAttachment != null) {
+                attachmentsObj.add(commitAttachment);
+            }
 
             if( attachmentsObj.size() > 0 ) {
                 payloadObj.add("attachments", attachmentsObj);
@@ -358,6 +333,41 @@ public class SlackServerAdapter extends BuildServerAdapter {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    private JsonObject createCommitAttachment(SRunningBuild build) {
+
+        List<SVcsModification>  changes =  build.getChanges(SelectPrevBuildPolicy.SINCE_LAST_SUCCESSFULLY_FINISHED_BUILD, true);
+
+        StringBuilder commitMessage = new StringBuilder();
+
+            /*
+             * If this field starts to feel too long in slack, we should only use the first item in the array, which would be the latest change
+             *
+             */
+        for ( int i = 0 ; i < changes.size() ; i++ ){
+            SVcsModification modification = changes.get(i);
+            String desc = modification.getDescription();
+            commitMessage.append(desc);
+
+            if( i < changes.size() - 1 ) {
+                commitMessage.append("\n------\n");
+            }
+        }
+
+        if (changes.size() < 1) {
+            return null;
+        }
+
+        String commitMessageString = commitMessage.toString();
+        JsonObject attachment = new JsonObject();
+        attachment.addProperty("title", "Commit Messages");
+        attachment.addProperty("fallback" , commitMessageString);
+        attachment.addProperty("text" , commitMessageString);
+        attachment.addProperty("color" , "#2FA8B9");
+
+        return attachment;
+
     }
 
 }

--- a/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
@@ -348,10 +348,11 @@ public class SlackServerAdapter extends BuildServerAdapter {
         for ( int i = 0 ; i < changes.size() ; i++ ){
             SVcsModification modification = changes.get(i);
             String desc = modification.getDescription();
+            commitMessage.append("‣ ");
             commitMessage.append(desc);
 
             if( i < changes.size() - 1 ) {
-                commitMessage.append("\n------\n");
+                commitMessage.append("\n");
             }
         }
 

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -4,7 +4,7 @@
     <info>
         <name>slackNotifier</name> <!-- the name of plugin used in teamcity -->
         <display-name>Slack Notifier</display-name>
-        <version>4.1.0</version>
+        <version>4.1.1</version>
         <description>Post build success notifications to Slack</description>
         <vendor>
             <name>Tapadoo</name>

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -4,7 +4,7 @@
     <info>
         <name>slackNotifier</name> <!-- the name of plugin used in teamcity -->
         <display-name>Slack Notifier</display-name>
-        <version>4.0.2</version>
+        <version>4.1.0</version>
         <description>Post build success notifications to Slack</description>
         <vendor>
             <name>Tapadoo</name>


### PR DESCRIPTION
Moved the commit message to it's own attachment to allow it hide and expand if needed. Refactored the creation of the attachment into it's own method.