### PR TITLE
print version number as teamcity recognisable buildNumber

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ apply plugin: 'java'
 
 sourceCompatibility = 1.8
 version = '4.4.1'
+println("##teamcity[buildNumber '$version']")
 
 configurations {
     deploy


### PR DESCRIPTION
This will print the current version being used by the project to the console so teamcity can pick it up and use it as the build number when posting the slack message.