### PR TITLE
duplicate check fix

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,6 @@
+# 2023.2
+Faulty check for dupliates - trying to fix again
+
 # 2023.1
 * changing version scheme, attempting a quick fix for repeated issues
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'java'
 
 
 sourceCompatibility = 1.8
-version = '2023.1'
+version = '2023.2'
 println("##teamcity[buildNumber '$version']")
 
 configurations {

--- a/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
+++ b/src/main/java/com/tapadoo/slacknotifier/SlackServerAdapter.java
@@ -280,12 +280,18 @@ public class SlackServerAdapter extends BuildServerAdapter {
                 // Filter the isseues by id - NOTE: I tried fancier language features , but I had issues with syntax, sdk, and compiling
                 // so it was quicker to write a traditional, inefficient nested loop than it was to improve my java
                 for (Issue issue : build.getRelatedIssues()) {
+                    boolean exists = false ;
+                    
                     for (Issue existingIssue : issues) {
                         if (existingIssue.getId().equalsIgnoreCase(issue.getId())) {
+                            exists = true;
                             break;
                         }
                     }   
-                    issues.add(issue);
+
+                    if (!exists) {
+                        issues.add(issue);
+                    }
                 }
 
                 StringBuilder issueIds = new StringBuilder();

--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -4,7 +4,7 @@
     <info>
         <name>tpSlackNotifier</name> <!-- the name of plugin used in teamcity -->
         <display-name>Tapadoo Slack Notifier</display-name>
-        <version>2023.1</version>
+        <version>2023.2</version>
         <description>Post build success notifications to Slack</description>
         <vendor>
             <name>Tapadoo</name>


### PR DESCRIPTION
the last change didn't properly skip adding duplicates , due to the break only breaking the inner loop. Being more specific with a check var.

I've built and deployed this already, it's working for normal builds I'm just waiting to confirm it doesn't duplicate again.